### PR TITLE
[feat] Chat API/필드 수정과 Schedule GET/PUT API 개발

### DIFF
--- a/src/main/java/Ness/Backend/domain/Schedule.java
+++ b/src/main/java/Ness/Backend/domain/Schedule.java
@@ -1,15 +1,20 @@
 package Ness.Backend.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Schedule {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "schedule_id")
-    private String id;
+    private Long id;
 
     private String info;
 
@@ -31,5 +36,18 @@ public class Schedule {
     @OneToOne
     @JoinColumn(name = "chat_id")
     private Chat chat;
+
+    @Builder
+    public Schedule(Long id, String info, String location, String person, ScheduleDate scheduleDate,
+                    Member member, Category category, Chat chat) {
+        this.id = id;
+        this.info = info;
+        this.location = location;
+        this.person = person;
+        this.scheduleDate = scheduleDate;
+        this.member = member;
+        this.category = category;
+        this.chat = chat;
+    }
 
 }

--- a/src/main/java/Ness/Backend/domain/ScheduleDate.java
+++ b/src/main/java/Ness/Backend/domain/ScheduleDate.java
@@ -3,13 +3,20 @@ package Ness.Backend.domain;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor
-@AllArgsConstructor
+@Getter
 public class ScheduleDate {
     private String time;
     private String date;
+
+    @Builder
+    public ScheduleDate(String time, String date){
+        this.time = time;
+        this.date = date;
+    }
 }

--- a/src/main/java/Ness/Backend/schedule/ScheduleController.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Schedule API", description = "사용자의 스케쥴 내역 관련 API")
 public class ScheduleController {
     private final ScheduleService scheduleService;
-    @GetMapping("/schedule")
+    @GetMapping("/schedule/user")
     @Operation(summary = "특정 사용자의 스케쥴 내역", description = "특정 사용자의 모든 스케쥴 내역을 반환하는 API 입니다.")
     public ResponseEntity<ScheduleListResponseDto> getOneUserSchedule(@RequestBody ScheduleRequestDto scheduleRequestDto){
         ScheduleListResponseDto oneUserSchedules = scheduleService.findOneUserSchedule(scheduleRequestDto.getMember_id());

--- a/src/main/java/Ness/Backend/schedule/ScheduleController.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleController.java
@@ -1,0 +1,34 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.chat.ChatCreateRequestDto;
+import Ness.Backend.chat.ChatListResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Schedule API", description = "사용자의 스케쥴 내역 관련 API")
+public class ScheduleController {
+    private final ScheduleService scheduleService;
+    @GetMapping("/schedule")
+    @Operation(summary = "특정 사용자의 스케쥴 내역", description = "특정 사용자의 모든 스케쥴 내역을 반환하는 API 입니다.")
+    public ResponseEntity<ScheduleListResponseDto> getOneUserSchedule(@RequestBody ScheduleRequestDto scheduleRequestDto){
+        ScheduleListResponseDto oneUserSchedules = scheduleService.findOneUserSchedule(scheduleRequestDto.getMember_id());
+        return new ResponseEntity<>(oneUserSchedules, HttpStatusCode.valueOf(200));
+    }
+
+    @PutMapping("/schedule/new")
+    @Operation(summary = "새로운 스케쥴 내역", description = "새로운 스케쥴 내역 저장하는 API 입니다.")
+    public ResponseEntity<Long> createSchedule(@RequestBody ScheduleCreateRequestDto scheduleCreateRequestDto){
+        Long userId  = scheduleService.createNewSchedule(scheduleCreateRequestDto);
+        return new ResponseEntity<>(userId, HttpStatusCode.valueOf(200));
+    }
+
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleCreateRequestDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleCreateRequestDto.java
@@ -1,0 +1,30 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.domain.ChatType;
+import Ness.Backend.domain.ScheduleDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleCreateRequestDto {
+    @Schema(description = "맴버 고유 인식 넘버", example = "0")
+    private Long member_id;
+
+    @Schema(description = "스케쥴 텍스트 내용", example = "AI 공부")
+    private String info;
+
+    @Schema(description = "스케쥴 위치", example = "이화여대 ECC")
+    private String location;
+
+    @Schema(description = "스케쥴 사람", example = "영희")
+    private String person;
+
+    @Schema(description = "스케쥴 날짜", example = "01월 31일 10시 30분")
+    private ScheduleDate scheduleDate;
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleCreateRequestDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleCreateRequestDto.java
@@ -2,6 +2,7 @@ package Ness.Backend.schedule;
 
 import Ness.Backend.domain.ChatType;
 import Ness.Backend.domain.ScheduleDate;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,6 +26,7 @@ public class ScheduleCreateRequestDto {
     @Schema(description = "스케쥴 사람", example = "영희")
     private String person;
 
+    @JsonProperty("scheduleDate")
     @Schema(description = "스케쥴 날짜", example = "01월 31일 10시 30분")
-    private ScheduleDate scheduleDate;
+    private ScheduleDateDto scheduleDateDto;
 }

--- a/src/main/java/Ness/Backend/schedule/ScheduleDateDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleDateDto.java
@@ -1,0 +1,20 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.domain.ScheduleDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleDateDto {
+    @Schema(description = "스케쥴 시간", example = "12:00 PM")
+    private String time;
+
+    @Schema(description = "스케쥴 날짜", example = "2022-02-15")
+    private String date;
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleDto.java
@@ -1,0 +1,28 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.domain.ScheduleDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleDto {
+    @Schema(description = "스케쥴 고유 인식 넘버", example = "0")
+    private Long id;
+
+    @Schema(description = "스케쥴 텍스트 내용", example = "AI 공부")
+    private String info;
+
+    @Schema(description = "스케쥴 위치", example = "이화여대 ECC")
+    private String location;
+
+    @Schema(description = "스케쥴 날짜", example = "01월 31일 10시 30분")
+    private ScheduleDate scheduleDate;
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleDto.java
@@ -1,6 +1,7 @@
 package Ness.Backend.schedule;
 
 import Ness.Backend.domain.ScheduleDate;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +24,7 @@ public class ScheduleDto {
     @Schema(description = "스케쥴 위치", example = "이화여대 ECC")
     private String location;
 
+    @JsonProperty("scheduleDate")
     @Schema(description = "스케쥴 날짜", example = "01월 31일 10시 30분")
-    private ScheduleDate scheduleDate;
+    private ScheduleDateDto scheduleDateDto;
 }

--- a/src/main/java/Ness/Backend/schedule/ScheduleListResponseDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleListResponseDto.java
@@ -1,0 +1,17 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.chat.ChatDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleListResponseDto {
+    private List<ScheduleDto> scheduleList;
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleRepository.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleRepository.java
@@ -1,0 +1,13 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.domain.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    // 특정 맴버 ID로 스케줄 리스트 반환
+    List<Schedule> findByMember_Id(Long memberId);
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleRequestDto.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleRequestDto.java
@@ -1,0 +1,17 @@
+package Ness.Backend.schedule;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleRequestDto {
+    @Schema(description = "맴버 고유 인식 넘버", example = "0")
+    private Long member_id;
+}

--- a/src/main/java/Ness/Backend/schedule/ScheduleService.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleService.java
@@ -6,6 +6,7 @@ import Ness.Backend.chat.ChatListResponseDto;
 import Ness.Backend.domain.Chat;
 import Ness.Backend.domain.Member;
 import Ness.Backend.domain.Schedule;
+import Ness.Backend.domain.ScheduleDate;
 import Ness.Backend.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,7 +31,10 @@ public class ScheduleService {
                         .id(schedule.getId())
                         .info(schedule.getInfo())
                         .location(schedule.getLocation())
-                        .scheduleDate(schedule.getScheduleDate())
+                        .scheduleDateDto(new ScheduleDateDto.ScheduleDateDtoBuilder()
+                                .time(schedule.getScheduleDate().getTime())
+                                .date(schedule.getScheduleDate().getDate())
+                                .build())
                         .build())
                 .toList();
         return new ScheduleListResponseDto(scheduleDtos);
@@ -40,16 +44,22 @@ public class ScheduleService {
     public Long createNewSchedule(ScheduleCreateRequestDto scheduleCreateRequestDto){
         Member memberEntity = memberRepository.findMemberById(scheduleCreateRequestDto.getMember_id());
 
+        ScheduleDate newScheduleDate = ScheduleDate.builder()
+                .time(scheduleCreateRequestDto.getScheduleDateDto().getTime())
+                .date(scheduleCreateRequestDto.getScheduleDateDto().getDate())
+                .build();
+
         //새로운 채팅 생성
         Schedule newSchedule = Schedule.builder()
                 .info(scheduleCreateRequestDto.getInfo())
                 .location(scheduleCreateRequestDto.getLocation())
                 .person(scheduleCreateRequestDto.getPerson())
-                .scheduleDate(scheduleCreateRequestDto.getScheduleDate())
+                .scheduleDate(newScheduleDate)
                 .member(memberEntity)
                 //.category() //이 연관관계들은 나중에 넣어야 함
                 //.chat()
                 .build();
+
         scheduleRepository.save(newSchedule);
         return newSchedule.getId(); // 저장한 Chat 확인용
     }

--- a/src/main/java/Ness/Backend/schedule/ScheduleService.java
+++ b/src/main/java/Ness/Backend/schedule/ScheduleService.java
@@ -1,0 +1,56 @@
+package Ness.Backend.schedule;
+
+import Ness.Backend.chat.ChatCreateRequestDto;
+import Ness.Backend.chat.ChatDto;
+import Ness.Backend.chat.ChatListResponseDto;
+import Ness.Backend.domain.Chat;
+import Ness.Backend.domain.Member;
+import Ness.Backend.domain.Schedule;
+import Ness.Backend.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScheduleService {
+    private final ScheduleRepository scheduleRepository;
+    private final MemberRepository memberRepository;
+
+    public ScheduleListResponseDto findOneUserSchedule(Long id){
+        List<Schedule> scheduleList = scheduleRepository.findByMember_Id(id);
+
+        // ScheduleListResponseDto에 매핑
+        List<ScheduleDto> scheduleDtos = scheduleList.stream()
+                .map(schedule -> new ScheduleDto.ScheduleDtoBuilder()
+                        .id(schedule.getId())
+                        .info(schedule.getInfo())
+                        .location(schedule.getLocation())
+                        .scheduleDate(schedule.getScheduleDate())
+                        .build())
+                .toList();
+        return new ScheduleListResponseDto(scheduleDtos);
+    }
+
+    @Transactional
+    public Long createNewSchedule(ScheduleCreateRequestDto scheduleCreateRequestDto){
+        Member memberEntity = memberRepository.findMemberById(scheduleCreateRequestDto.getMember_id());
+
+        //새로운 채팅 생성
+        Schedule newSchedule = Schedule.builder()
+                .info(scheduleCreateRequestDto.getInfo())
+                .location(scheduleCreateRequestDto.getLocation())
+                .person(scheduleCreateRequestDto.getPerson())
+                .scheduleDate(scheduleCreateRequestDto.getScheduleDate())
+                .member(memberEntity)
+                //.category() //이 연관관계들은 나중에 넣어야 함
+                //.chat()
+                .build();
+        scheduleRepository.save(newSchedule);
+        return newSchedule.getId(); // 저장한 Chat 확인용
+    }
+}


### PR DESCRIPTION
1. AI/USER의 새로운 Chat을 PUT하는 API 개발(RDB에 저장)
2. Chat 객체에 Type 필드(USER, AI) 넣기
3. 특정 맴버의 전체 Schedule을 GET하는 API 개발
4. 특정 맴버의 새로운 Schedule을 PUT하는 API 개발
