### PR TITLE
[fix] 로그인/회원가입 구글 로그인 API를 하나로 통합

### DIFF
--- a/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Controller.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Controller.java
@@ -14,10 +14,4 @@ public class OAuth2Controller {
         String loginMessage = oAuth2Service.socialLogin(code, registration);
         return CommonResponse.postResponse(HttpStatus.OK.value(), loginMessage);
     }
-
-    @PostMapping("/signup/oauth/{registration}")
-    public CommonResponse<?> socialSignUp(@RequestParam String code, @PathVariable String registration) {
-        String registerMessage = oAuth2Service.socialSignUp(code, registration);
-        return CommonResponse.postResponse(HttpStatus.CREATED.value(), registerMessage);
-    }
 }


### PR DESCRIPTION
1. 기존 구글 로그인은 로그인/회원 가입 기능이 각각 API가 분리되어 있었음. 이를 OAuth 인증->DB에 없으면 회원가입, 있으면 로그인으로 합쳐서 사용자의 flow를 개선함.