### PR TITLE
[🚀feat] kakao login 기능 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//FeignClient
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	//Object Mapper
+	//implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
 }
 
 dependencyManagement {

--- a/src/main/java/Ness/Backend/domain/auth/dto/ResourceDto.java
+++ b/src/main/java/Ness/Backend/domain/auth/dto/ResourceDto.java
@@ -1,0 +1,28 @@
+package Ness.Backend.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+public class ResourceDto {
+    private String id;
+
+    private String email;
+
+    private String picture;
+
+    private String nickname;
+
+    @Builder
+    public ResourceDto(String id, String email, String picture, String nickname){
+        this.id = id;
+        this.email = email;
+        this.picture = picture;
+        this.nickname = nickname;
+    }
+}
+

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Controller.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Controller.java
@@ -1,6 +1,5 @@
 package Ness.Backend.domain.auth.oAuth;
 
-import Ness.Backend.domain.auth.oAuth.dto.GoogleResourceDto;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.global.auth.AuthUser;
 import Ness.Backend.global.common.response.CommonResponse;

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Service.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Service.java
@@ -1,35 +1,22 @@
 package Ness.Backend.domain.auth.oAuth;
 
 import Ness.Backend.domain.auth.inmemory.RefreshTokenRepository;
-import Ness.Backend.domain.auth.oAuth.dto.GoogleResourceDto;
-import Ness.Backend.domain.auth.oAuth.dto.GoogleTokenDto;
-import Ness.Backend.domain.auth.security.AuthDetails;
+import Ness.Backend.domain.auth.oAuth.google.dto.GoogleResourceDto;
+import Ness.Backend.domain.auth.oAuth.google.dto.GoogleTokenDto;
 import Ness.Backend.domain.auth.jwt.JwtTokenProvider;
 import Ness.Backend.domain.member.MemberService;
-import Ness.Backend.domain.profile.ProfileRepository;
-import Ness.Backend.domain.profile.entity.Profile;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.domain.member.MemberRepository;
-import Ness.Backend.global.auth.oAuth.dto.GoogleOAuthApi;
-import Ness.Backend.global.auth.oAuth.dto.GoogleResourceApi;
+import Ness.Backend.global.auth.oAuth.google.GoogleOAuthApi;
+import Ness.Backend.global.auth.oAuth.google.GoogleResourceApi;
 import Ness.Backend.global.error.ErrorCode;
 import Ness.Backend.global.error.exception.UnauthorizedException;
-import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.util.Pair;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 
 @Service

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/google/dto/GoogleResourceDto.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/google/dto/GoogleResourceDto.java
@@ -1,4 +1,4 @@
-package Ness.Backend.domain.auth.oAuth.dto;
+package Ness.Backend.domain.auth.oAuth.google.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/google/dto/GoogleTokenDto.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/google/dto/GoogleTokenDto.java
@@ -1,4 +1,4 @@
-package Ness.Backend.domain.auth.oAuth.dto;
+package Ness.Backend.domain.auth.oAuth.google.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoAccount.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoAccount.java
@@ -1,7 +1,6 @@
 package Ness.Backend.domain.auth.oAuth.kakao.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,10 +8,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor
-public class KakaoResourceDto {
-    @JsonProperty("id")
-    private String id;
-
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
+public class KakaoAccount {
+    @JsonProperty("profile")
+    private KakaoProfile kakaoProfile;
+    @JsonProperty("email")
+    private String email;
 }

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoProfile.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoProfile.java
@@ -1,7 +1,6 @@
 package Ness.Backend.domain.auth.oAuth.kakao.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,10 +8,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor
-public class KakaoResourceDto {
-    @JsonProperty("id")
-    private String id;
+public class KakaoProfile {
+    @JsonProperty("profile_image_url")
+    private String picture;
 
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
+    @JsonProperty("nickname")
+    private String nickname;
 }

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoResourceDto.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoResourceDto.java
@@ -1,0 +1,32 @@
+package Ness.Backend.domain.auth.oAuth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+public class KakaoResourceDto {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("profile_image_url")
+    private String picture;
+
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @Builder
+    public KakaoResourceDto(String id, String email, String picture, String nickname){
+        this.id = id;
+        this.email = email;
+        this.picture = picture;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoTokenDto.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/kakao/dto/KakaoTokenDto.java
@@ -1,0 +1,18 @@
+package Ness.Backend.domain.auth.oAuth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoTokenDto {
+    @NotNull(message = "accessToken may not be null")
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleOAuthApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleOAuthApi.java
@@ -1,8 +1,6 @@
-package Ness.Backend.global.auth.oAuth.google.dto;
+package Ness.Backend.global.auth.oAuth.google;
 
-import Ness.Backend.domain.auth.oAuth.dto.GoogleTokenDto;
-import feign.Headers;
-import org.springframework.beans.factory.annotation.Value;
+import Ness.Backend.domain.auth.oAuth.google.dto.GoogleTokenDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleOAuthApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleOAuthApi.java
@@ -1,4 +1,4 @@
-package Ness.Backend.global.auth.oAuth.dto;
+package Ness.Backend.global.auth.oAuth.google.dto;
 
 import Ness.Backend.domain.auth.oAuth.dto.GoogleTokenDto;
 import feign.Headers;

--- a/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleResourceApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleResourceApi.java
@@ -1,12 +1,9 @@
-package Ness.Backend.global.auth.oAuth.google.dto;
+package Ness.Backend.global.auth.oAuth.google;
 
-import Ness.Backend.domain.auth.oAuth.dto.GoogleResourceDto;
-import feign.Headers;
-import feign.Param;
+import Ness.Backend.domain.auth.oAuth.google.dto.GoogleResourceDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(

--- a/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleResourceApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/google/GoogleResourceApi.java
@@ -1,4 +1,4 @@
-package Ness.Backend.global.auth.oAuth.dto;
+package Ness.Backend.global.auth.oAuth.google.dto;
 
 import Ness.Backend.domain.auth.oAuth.dto.GoogleResourceDto;
 import feign.Headers;

--- a/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoOAuthApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoOAuthApi.java
@@ -1,0 +1,23 @@
+package Ness.Backend.global.auth.oAuth.kakao;
+
+import Ness.Backend.domain.auth.oAuth.kakao.dto.KakaoTokenDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+        name = "KakaoOAuth",
+        url = "https://kauth.kakao.com")
+public interface KakaoOAuthApi {
+    @PostMapping(
+            value = "/oauth/token?" +
+                    "code={CODE}" +
+                    "&client_id={CLIENT_ID}" +
+                    "&redirect_uri={REDIRECT_URI}" +
+                    "&grant_type={GRANT_TYPE}")
+    KakaoTokenDto kakaoGetToken(
+            @PathVariable("CODE") String code,
+            @PathVariable("CLIENT_ID") String clientId,
+            @PathVariable("REDIRECT_URI") String redirectUri,
+            @PathVariable("GRANT_TYPE") String grantType);
+}

--- a/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoOAuthApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoOAuthApi.java
@@ -13,11 +13,13 @@ public interface KakaoOAuthApi {
             value = "/oauth/token?" +
                     "code={CODE}" +
                     "&client_id={CLIENT_ID}" +
+                    "&client_secret={CLIENT_SECRET}" +
                     "&redirect_uri={REDIRECT_URI}" +
                     "&grant_type={GRANT_TYPE}")
     KakaoTokenDto kakaoGetToken(
             @PathVariable("CODE") String code,
             @PathVariable("CLIENT_ID") String clientId,
+            @PathVariable("CLIENT_SECRET") String clientSecret,
             @PathVariable("REDIRECT_URI") String redirectUri,
             @PathVariable("GRANT_TYPE") String grantType);
 }

--- a/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoResourceApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoResourceApi.java
@@ -1,0 +1,15 @@
+package Ness.Backend.global.auth.oAuth.kakao;
+
+import Ness.Backend.domain.auth.oAuth.kakao.dto.KakaoResourceDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+        name = "KakaoOAuth",
+        url = "https://kapi.kakao.com")
+public interface KakaoResourceApi {
+    @GetMapping(
+            value = "/v2/user/me")
+    KakaoResourceDto kakaoGetResource(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoResourceApi.java
+++ b/src/main/java/Ness/Backend/global/auth/oAuth/kakao/KakaoResourceApi.java
@@ -1,15 +1,17 @@
 package Ness.Backend.global.auth.oAuth.kakao;
 
 import Ness.Backend.domain.auth.oAuth.kakao.dto.KakaoResourceDto;
+import com.fasterxml.jackson.core.JsonParser;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(
-        name = "KakaoOAuth",
+        name = "KakaoResource",
         url = "https://kapi.kakao.com")
 public interface KakaoResourceApi {
     @GetMapping(
             value = "/v2/user/me")
-    KakaoResourceDto kakaoGetResource(@RequestHeader("Authorization") String accessToken);
+    KakaoResourceDto kakaoGetResource(@RequestHeader("Authorization") String accessToken,
+                                      @RequestHeader("Content-type") String contentType);
 }


### PR DESCRIPTION
1. 카카오 로그인 및 회원가입을 OpenFeign을 사용해서 구현 완료, 테스트 성공
2. JSON 맵핑을 Object Mapper가 아니라 dto로 구현 완료
3. redirect url을 프론트엔드 URL로 변경 완료, access token 검증 시 사용 가능하도록 함