### PR TITLE
[!HOTFIX] 토큰 응답 형식을 dto로 변경, HTTP Body에 전송

### DIFF
--- a/src/main/java/Ness/Backend/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/Ness/Backend/domain/auth/jwt/JwtTokenProvider.java
@@ -53,8 +53,8 @@ public class JwtTokenProvider {
     public JwtToken generateJwtToken(String authKey) throws HttpServerErrorException.InternalServerError {
         final Date now = new Date();
         return JwtToken.builder()
-                .jwtAccessToken(generateAccessToken(authKey, now))
-                .jwtRefreshToken(generateRefreshToken(authKey, now))
+                .jwtAccessToken("Bearer " + generateAccessToken(authKey, now))
+                .jwtRefreshToken("Bearer " + generateRefreshToken(authKey, now))
                 .build();
     }
 

--- a/src/main/java/Ness/Backend/domain/auth/jwt/entity/JwtToken.java
+++ b/src/main/java/Ness/Backend/domain/auth/jwt/entity/JwtToken.java
@@ -1,5 +1,6 @@
 package Ness.Backend.domain.auth.jwt.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,7 +8,10 @@ import java.util.Date;
 
 @Getter
 public class JwtToken {
+    @JsonProperty("access_token")
     private String jwtAccessToken;
+
+    @JsonProperty("refresh_token")
     private String jwtRefreshToken;
 
     @Builder

--- a/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Controller.java
+++ b/src/main/java/Ness/Backend/domain/auth/oAuth/OAuth2Controller.java
@@ -1,11 +1,15 @@
 package Ness.Backend.domain.auth.oAuth;
 
+import Ness.Backend.domain.auth.jwt.entity.JwtToken;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.global.auth.AuthUser;
 import Ness.Backend.global.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.UnsupportedEncodingException;
@@ -23,9 +27,8 @@ public class OAuth2Controller {
 
     @PostMapping("/login/oauth/{registration}")
     @Operation(summary = "OAuth 로그인 요청", description = "구글 계정으로 로그인하는 API 입니다.")
-    public CommonResponse<?> socialLogin(@RequestParam String code, @PathVariable String registration) {
-        String loginMessage = oAuth2Service.socialLogin(code, registration);
-        return CommonResponse.postResponse(HttpStatus.OK.value(), loginMessage);
+    public ResponseEntity<?> socialLogin(@RequestParam String code, @PathVariable String registration) {
+        return new ResponseEntity<>(oAuth2Service.socialLogin(code, registration), HttpStatusCode.valueOf(200));
     }
 
     @PostMapping("/logout/oauth/{registration}")


### PR DESCRIPTION
1. 토큰 응답 형식이 Header였던 것을 수정해 Body 전송으로 변경
2. 기존의 폼 응답 방식이었던 jwtToken 프로바이더를 Oauth 로그인 요청이 있을 때 전송하는 것으로 변경