### PR TITLE
[🚀feat] 구글 계정과 Thymeleaf 템플릿으로 email feature 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	//Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	//Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	//thymeleaf(for email service)
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/Ness/Backend/domain/email/EmailController.java
+++ b/src/main/java/Ness/Backend/domain/email/EmailController.java
@@ -1,6 +1,5 @@
 package Ness.Backend.domain.email;
 
-import Ness.Backend.domain.chat.dto.ChatListResponseDto;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.global.auth.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +8,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,9 +18,16 @@ public class EmailController {
     private final EmailService emailService;
 
     @GetMapping("/overview")
-    @Operation(summary = "하루 할일의 오버뷰 제공 API", description = "오늘의 할 일 오버뷰를 이메일로 제공해주는 API 입니다.")
+    @Operation(summary = "/하루 할일의 오버뷰 제공 API", description = "오늘의 할 일 오버뷰를 이메일로 제공해주는 API 입니다.")
     public ResponseEntity<?> sendOverview(@AuthUser Member member){
         emailService.sendEmailNotice(member.getEmail());
+        return new ResponseEntity<>(HttpStatusCode.valueOf(200));
+    }
+
+    @GetMapping("/dev/overview")
+    @Operation(summary = "개발용 하루 할일의 오버뷰 제공 API", description = "오늘의 할 일 오버뷰를 이메일로 제공해주는 API 입니다.")
+    public ResponseEntity<?> sendDevOverview(@RequestParam String email){
+        emailService.sendEmailNotice(email);
         return new ResponseEntity<>(HttpStatusCode.valueOf(200));
     }
 }

--- a/src/main/java/Ness/Backend/domain/email/EmailController.java
+++ b/src/main/java/Ness/Backend/domain/email/EmailController.java
@@ -1,0 +1,26 @@
+package Ness.Backend.domain.email;
+
+import Ness.Backend.domain.chat.dto.ChatListResponseDto;
+import Ness.Backend.domain.member.entity.Member;
+import Ness.Backend.global.auth.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/email")
+public class EmailController {
+    private final EmailService emailService;
+
+    @GetMapping("/overview")
+    @Operation(summary = "하루 할일의 오버뷰 제공 API", description = "오늘의 할 일 오버뷰를 이메일로 제공해주는 API 입니다.")
+    public ResponseEntity<?> sendOverview(@AuthUser Member member){
+        emailService.sendEmailNotice(member.getEmail());
+        return new ResponseEntity<>(HttpStatusCode.valueOf(200));
+    }
+}

--- a/src/main/java/Ness/Backend/domain/email/EmailService.java
+++ b/src/main/java/Ness/Backend/domain/email/EmailService.java
@@ -1,0 +1,16 @@
+package Ness.Backend.domain.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender javaMailSender;
+    /*
+    @Async
+    public boolean sendMail()
+     */
+}

--- a/src/main/java/Ness/Backend/domain/email/EmailService.java
+++ b/src/main/java/Ness/Backend/domain/email/EmailService.java
@@ -1,16 +1,56 @@
 package Ness.Backend.domain.email;
 
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.thymeleaf.context.Context;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
 public class EmailService {
     private final JavaMailSender javaMailSender;
-    /*
+    private final SpringTemplateEngine templateEngine;
     @Async
-    public boolean sendMail()
-     */
+    public void sendEmailNotice(String email){
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(email); // 메일 수신자
+            mimeMessageHelper.setSubject("Today's Overview on NESS"); // 메일 제목
+            mimeMessageHelper.setText(setContext(todayDate()), true); // 메일 본문 내용, HTML 여부
+            javaMailSender.send(mimeMessage);
+
+            log.info("Succeeded to send Email");
+        } catch (Exception e) {
+            log.info("Failed to send Email");
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String todayDate(){
+        ZonedDateTime todayDate = LocalDateTime.now(ZoneId.of("Asia/Seoul")).atZone(ZoneId.of("Asia/Seoul"));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M월 d일");
+        return todayDate.format(formatter);
+    }
+
+    //thymeleaf를 통한 html 적용
+    public String setContext(String date) {
+        Context context = new Context();
+        context.setVariable("date", date);
+        return templateEngine.process("notice", context);
+    }
 }

--- a/src/main/java/Ness/Backend/global/config/MailConfig.java
+++ b/src/main/java/Ness/Backend/global/config/MailConfig.java
@@ -1,0 +1,67 @@
+package Ness.Backend.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+    private static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
+    private static final String MAIL_DEBUG = "mail.smtp.debug";
+    private static final String MAIL_CONNECTION_TIMEOUT = "mail.smtp.connectiontimeout";
+    private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+
+    // SMTP 서버
+    @Value("${spring.mail.host}")
+    private String host;
+
+    // 계정
+    @Value("$spring.mail.username")
+    private String username;
+
+    // 비밀번호
+    @Value("$spring.mail.password")
+    private String password;
+
+    // 포트번호
+    @Value("$spring.mail.port")
+    private int port;
+
+    @Value("$spring.mail.properties.mail.smtp.auth")
+    private boolean auth;
+
+    @Value("$spring.mail.properties.mail.smtp.debug")
+    private boolean debug;
+
+    @Value("$spring.mail.properties.mail.smtp.connectiontimeout")
+    private int connectionTimeout;
+
+    @Value("$spring.mail.properties.mail.starttls.enable")
+    private boolean startTlsEnable;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+
+        Properties properties = javaMailSender.getJavaMailProperties();
+        properties.put(MAIL_SMTP_AUTH, auth);
+        properties.put(MAIL_DEBUG, debug);
+        properties.put(MAIL_CONNECTION_TIMEOUT, connectionTimeout);
+        properties.put(MAIL_SMTP_STARTTLS_ENABLE, startTlsEnable);
+
+        javaMailSender.setJavaMailProperties(properties);
+        javaMailSender.setDefaultEncoding("UTF-8");
+
+        return javaMailSender;
+    }
+}

--- a/src/main/java/Ness/Backend/global/config/MailConfig.java
+++ b/src/main/java/Ness/Backend/global/config/MailConfig.java
@@ -22,27 +22,27 @@ public class MailConfig {
     private String host;
 
     // 계정
-    @Value("$spring.mail.username")
+    @Value("${spring.mail.username}")
     private String username;
 
     // 비밀번호
-    @Value("$spring.mail.password")
+    @Value("${spring.mail.password}")
     private String password;
 
     // 포트번호
-    @Value("$spring.mail.port")
+    @Value("${spring.mail.port}")
     private int port;
 
-    @Value("$spring.mail.properties.mail.smtp.auth")
+    @Value("${spring.mail.properties.mail.smtp.auth}")
     private boolean auth;
 
-    @Value("$spring.mail.properties.mail.smtp.debug")
+    @Value("${spring.mail.properties.mail.smtp.debug}")
     private boolean debug;
 
-    @Value("$spring.mail.properties.mail.smtp.connectiontimeout")
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
     private int connectionTimeout;
 
-    @Value("$spring.mail.properties.mail.starttls.enable")
+    @Value("${spring.mail.properties.mail.starttls.enable}")
     private boolean startTlsEnable;
 
     @Bean

--- a/src/main/resources/templates/email/notice.html
+++ b/src/main/resources/templates/email/notice.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+    <h1>Today's Overview on NESS</h1>
+    <br>
+    <p th:text="'${date}' + '의 할일 목록입니다.'">오늘의 할일 목록입니다.</p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/notice.html
+++ b/src/main/resources/templates/notice.html
@@ -5,7 +5,7 @@
 <div style="margin:100px;">
     <h1>Today's Overview on NESS</h1>
     <br>
-    <p th:text="'${date}' + '의 할일 목록입니다.'">오늘의 할일 목록입니다.</p>
+    <p th:text="|${date}의 할일 목록입니다.|">오늘의 할일 목록입니다.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
1. Thymeleaf 템플릿 간단하게 추가(오늘의 overview 관련 템플릿)
2. 구글 계정(NESS의 공식 계정)으로 이메일 전송 설정 완료, application.yml 및 MailConfig.java에 설정 적용
3. NESS 공식 계정->내 계정으로 이메일 전송 테스트 완료