### PR TITLE
[🚀feat] JWT 토큰 관련 에러 로직 추가 

### DIFF
--- a/src/main/java/Ness/Backend/domain/auth/AuthController.java
+++ b/src/main/java/Ness/Backend/domain/auth/AuthController.java
@@ -4,7 +4,7 @@ import Ness.Backend.domain.auth.dto.LoginRequestDto;
 import Ness.Backend.domain.auth.dto.RegisterRequestDto;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.global.auth.AuthUser;
-import Ness.Backend.global.common.response.CommonResponse;
+import Ness.Backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class AuthController {
     /* 스프링 시큐리티는 /login 경로의 요청을 받아 인증 과정을 처리 */
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "사용자의 이메일과 비밀번호로 로그인하는 API 입니다.")
-    public CommonResponse<?> userLogin(@RequestBody LoginRequestDto loginRequestDto) {
+    public ApiResponse<?> userLogin(@RequestBody LoginRequestDto loginRequestDto) {
         return authService.login(loginRequestDto);
     }
 
@@ -32,7 +32,7 @@ public class AuthController {
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입 API", description = "사용자의 이메일과 비밀번호로 회원가입하는 API 입니다.")
-    public CommonResponse<?> userRegister(@RequestBody RegisterRequestDto registerRequestDto) {
+    public ApiResponse<?> userRegister(@RequestBody RegisterRequestDto registerRequestDto) {
         return authService.signUp(registerRequestDto);
     }
 

--- a/src/main/java/Ness/Backend/domain/auth/AuthService.java
+++ b/src/main/java/Ness/Backend/domain/auth/AuthService.java
@@ -5,7 +5,7 @@ import Ness.Backend.domain.auth.dto.RegisterRequestDto;
 import Ness.Backend.domain.auth.security.AuthDetails;
 import Ness.Backend.domain.member.MemberRepository;
 import Ness.Backend.domain.member.entity.Member;
-import Ness.Backend.global.common.response.CommonResponse;
+import Ness.Backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -25,7 +25,7 @@ public class AuthService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     @Transactional
-    public CommonResponse<?> signUp(RegisterRequestDto registerRequestDto) {
+    public ApiResponse<?> signUp(RegisterRequestDto registerRequestDto) {
         try {
             /* 빌더 패턴을 사용해 MemberRole을 넘겨주지 않아도 객체 생성 가능 */
             Member member = Member.builder()
@@ -35,20 +35,20 @@ public class AuthService {
 
             memberRepository.save(member);
 
-            return CommonResponse.postResponse(
+            return ApiResponse.postResponse(
                     HttpStatus.OK.value(),
                     "회원가입이 완료되었습니다."); //200
 
         } catch (DataIntegrityViolationException e) {
             /* 중복된 이메일 값이 삽입되려고 할 때 발생하는 예외 처리 */
-            return CommonResponse.postResponse(
+            return ApiResponse.postResponse(
                     HttpStatus.CONFLICT.value(),
                     "이미 회원 가입된 유저입니다."); //409
         }
     }
 
     @Transactional
-    public CommonResponse<?> login(LoginRequestDto loginRequestDto) {
+    public ApiResponse<?> login(LoginRequestDto loginRequestDto) {
         String email = loginRequestDto.getEmail();
         String password = loginRequestDto.getPassword();
 
@@ -69,12 +69,12 @@ public class AuthService {
             String authenticatedEmail = authDetails.getMember().getEmail();
 
             /* JWT 토큰 반환 */
-            return CommonResponse.postResponse(
+            return ApiResponse.postResponse(
                     HttpStatus.OK.value(),
                     "로그인에 성공했습니다."); //200
         }
 
-        return CommonResponse.postResponse(
+        return ApiResponse.postResponse(
                 HttpStatus.UNAUTHORIZED.value(),
                 "로그인에 실패했습니다. 이메일 또는 비밀번호가 일치하는지 확인해주세요."); //401
     }

--- a/src/main/java/Ness/Backend/domain/auth/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/Ness/Backend/domain/auth/jwt/JwtAuthorizationFilter.java
@@ -5,6 +5,8 @@ import Ness.Backend.domain.auth.security.AuthDetails;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.global.error.ErrorCode;
 import static Ness.Backend.global.error.FilterExceptionHandler.setResponse;
+
+import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -65,6 +67,10 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             log.error("EXPIRED_TOKEN");
             request.setAttribute("exception", ErrorCode.EXPIRED_TOKEN.getCode());
             setResponse(response, ErrorCode.EXPIRED_TOKEN);
+        } catch (SignatureVerificationException e){
+            log.error("INVALID_TOKEN_SIGNATURE");
+            request.setAttribute("exception", ErrorCode.INVALID_TOKEN_SIGNATURE.getCode());
+            setResponse(response, ErrorCode.INVALID_TOKEN_SIGNATURE);
         }
     }
 }

--- a/src/main/java/Ness/Backend/domain/auth/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/Ness/Backend/domain/auth/jwt/JwtAuthorizationFilter.java
@@ -71,6 +71,10 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             log.error("INVALID_TOKEN_SIGNATURE");
             request.setAttribute("exception", ErrorCode.INVALID_TOKEN_SIGNATURE.getCode());
             setResponse(response, ErrorCode.INVALID_TOKEN_SIGNATURE);
+        } catch (Exception e){
+            log.error("TOKEN_EXCEPTION");
+            request.setAttribute("exception", ErrorCode.TOKEN_ERROR.getCode());
+            setResponse(response, ErrorCode.TOKEN_ERROR);
         }
     }
 }

--- a/src/main/java/Ness/Backend/domain/auth/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/Ness/Backend/domain/auth/jwt/JwtAuthorizationFilter.java
@@ -4,9 +4,8 @@ import Ness.Backend.domain.auth.security.AuthDetailService;
 import Ness.Backend.domain.auth.security.AuthDetails;
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.global.error.ErrorCode;
-import Ness.Backend.global.error.exception.ExpiredTokenException;
-import Ness.Backend.global.error.exception.UnauthorizedAccessException;
-import Ness.Backend.global.error.exception.UnauthorizedUserException;
+import static Ness.Backend.global.error.FilterExceptionHandler.setResponse;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,7 +16,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-
 import java.io.IOException;
 
 /* 사용자의 권한 부여
@@ -59,17 +57,14 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
                 /* 시큐리티 세션에 Authentication 을 저장 */
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
-        } catch (UnauthorizedAccessException e){
-            request.setAttribute("exception", ErrorCode.UNAUTHORIZED_ACCESS.getCode());
-            log.error("UNAUTHORIZED_ACCESS");
-        } catch (ExpiredTokenException e){
+           }
+
+            chain.doFilter(request, response);
+
+        } catch (TokenExpiredException e){
             log.error("EXPIRED_TOKEN");
             request.setAttribute("exception", ErrorCode.EXPIRED_TOKEN.getCode());
-        } catch (UnauthorizedUserException e){
-            log.error("UNAUTHORIZED_USER");
-            request.setAttribute("exception", ErrorCode.UNAUTHORIZED_USER.getCode());
+            setResponse(response, ErrorCode.EXPIRED_TOKEN);
         }
-        chain.doFilter(request, response);
     }
 }

--- a/src/main/java/Ness/Backend/domain/auth/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/Ness/Backend/domain/auth/security/JwtAuthenticationEntryPoint.java
@@ -9,27 +9,20 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 @Slf4j
-@Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    //BasicAuthenticationEntryPoint
+    //AuthenticationEntryPoint
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
-                         AuthenticationException e) throws IOException, ServletException {
+                         AuthenticationException authenticationException) throws IOException, ServletException {
         log.error("JwtAuthenticationEntryPoint 호출");
         String exception = (String)request.getAttribute("exception");
-        response.setCharacterEncoding("utf-8");
-
-        if(exception.equals(ErrorCode.UNAUTHORIZED_ACCESS.getCode())) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setCharacterEncoding("utf-8");
-            response.setContentType("application/json");
-        }
-        else if(exception.equals(ErrorCode.EXPIRED_TOKEN.getCode())) {
+        if(exception.equals(ErrorCode.EXPIRED_TOKEN.getCode())) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setCharacterEncoding("utf-8");
             response.setContentType("application/json");
@@ -37,15 +30,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             ObjectMapper objectMapper = new ObjectMapper();
             String result = objectMapper.writeValueAsString(expiredTokenException);
             response.getWriter().write(result);
-        }
-        else if(exception.equals(ErrorCode.UNAUTHORIZED_USER.getCode())) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setCharacterEncoding("utf-8");
-            response.setContentType("application/json");        }
-        else {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setCharacterEncoding("utf-8");
-            response.setContentType("application/json");
         }
     }
 }

--- a/src/main/java/Ness/Backend/domain/auth/security/SecurityConfig.java
+++ b/src/main/java/Ness/Backend/domain/auth/security/SecurityConfig.java
@@ -30,7 +30,6 @@ public class SecurityConfig {
     private final AuthDetailService authDetailService;
     private final AuthenticationConfiguration authenticationConfiguration;
     private final RefreshTokenService refreshTokenService;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     /* 회원가입: 패스워드 암호화를 위해 사용 */
     @Bean
@@ -82,9 +81,12 @@ public class SecurityConfig {
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션을 생성하지 않음->토큰 기반 인증 필요
                 .addFilter(new JwtAuthenticationFilter(authenticationManager(), jwtTokenProvider(), refreshTokenService))  //사용자 인증
                 .addFilter(new JwtAuthorizationFilter(authenticationManager(),  jwtTokenProvider(), authDetailService)) //사용자 권한 부여
-                .exceptionHandling((exceptionConfig) ->
-                        exceptionConfig.authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                ) //인가(Authorization)가 실패시 실행
+                /*
+                .exceptionHandling((exceptionHandling) ->
+
+                        exceptionHandling.authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                ) //인가(Authorization)가 실패시 실행, 항상 JwtAuthenticationFilter 뒤에 설정되어 있어야 함.
+                 */
                 .authorizeHttpRequests(requests -> requests
                         .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
                         //.requestMatchers("/signup/**", "/login/**").permitAll() // 회원가입 및 로그인 경로는 인증 생략

--- a/src/main/java/Ness/Backend/global/common/response/CommonResponse.java
+++ b/src/main/java/Ness/Backend/global/common/response/CommonResponse.java
@@ -1,8 +1,13 @@
 package Ness.Backend.global.common.response;
 
+import Ness.Backend.global.error.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
+import net.minidev.json.JSONObject;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class CommonResponse<T> {
     @JsonProperty("status")
@@ -41,6 +46,26 @@ public class CommonResponse<T> {
                 .success(true)
                 .message(message)
                 .data(data)
+                .build();
+    }
+
+
+    public static JSONObject jsonOf(ErrorCode errorCode) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        jsonObject.put("success", false);
+        jsonObject.put("message", errorCode.getMessage());
+        jsonObject.put("status", errorCode.getHttpStatus().value());
+        jsonObject.put("code", errorCode.getCode());
+        return jsonObject;
+    }
+
+    public static <T> CommonResponse<T> onFailure(ErrorCode errorCode, String message) {
+        return CommonResponse.<T>builder()
+                .code(errorCode.getHttpStatus().value())
+                .success(false)
+                .message(message)
+                .data(null)
                 .build();
     }
 }

--- a/src/main/java/Ness/Backend/global/error/ErrorCode.java
+++ b/src/main/java/Ness/Backend/global/error/ErrorCode.java
@@ -18,16 +18,16 @@ public enum ErrorCode {
 
     /* Auth */
     UNAUTHORIZED_ACCESS(UNAUTHORIZED, "AUTH000", "권한이 없습니다."),
-    EXPIRED_TOKEN(BAD_REQUEST, "AUTH001", "만료된 엑세스 토큰입니다"),
-    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AUTH002", "리프레시 토큰이 유효하지 않습니다"),
-    MISMATCH_REFRESH_TOKEN(BAD_REQUEST, "AUTH003", "리프레시 토큰의 유저 정보가 일치하지 않습니다"),
-    INVALID_AUTH_TOKEN(UNAUTHORIZED, "AUTH004", "권한 정보가 없는 토큰입니다"),
-    UNAUTHORIZED_USER(UNAUTHORIZED, "AUTH005", "현재 내 계정 정보가 존재하지 않습니다"),
-    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "AUTH006", "로그아웃 된 사용자입니다"),
-    FORBIDDEN_USER(FORBIDDEN, "AUTH007", "권한이 없는 유저입니다"),
-    LOGIN_FAILED(UNAUTHORIZED, "AUTH008", "로그인에 실패했습니다"),
-    INVALID_TOKEN(BAD_REQUEST, "AUTH009", "유효하지 않은 토큰입니다"),
-    INVALID_PRINCIPAL(BAD_REQUEST, "AUTH010", "인증정보가 존재하지 않습니다");
+    EXPIRED_TOKEN(BAD_REQUEST, "AUTH001", "만료된 엑세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AUTH002", "리프레시 토큰이 유효하지 않습니다."),
+    MISMATCH_REFRESH_TOKEN(BAD_REQUEST, "AUTH003", "리프레시 토큰의 유저 정보가 일치하지 않습니다."),
+    INVALID_AUTH_TOKEN(UNAUTHORIZED, "AUTH004", "권한 정보가 없는 토큰입니다."),
+    UNAUTHORIZED_USER(UNAUTHORIZED, "AUTH005", "현재 내 계정 정보가 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "AUTH006", "로그아웃 된 사용자입니다."),
+    FORBIDDEN_USER(FORBIDDEN, "AUTH007", "권한이 없는 유저입니다."),
+    LOGIN_FAILED(UNAUTHORIZED, "AUTH008", "로그인에 실패했습니다."),
+    INVALID_TOKEN(BAD_REQUEST, "AUTH009", "유효하지 않은 토큰입니다."),
+    INVALID_PRINCIPAL(BAD_REQUEST, "AUTH010", "인증정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Ness/Backend/global/error/ErrorCode.java
+++ b/src/main/java/Ness/Backend/global/error/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     FORBIDDEN_USER(FORBIDDEN, "AUTH007", "권한이 없는 유저입니다."),
     LOGIN_FAILED(UNAUTHORIZED, "AUTH008", "로그인에 실패했습니다."),
     INVALID_TOKEN(BAD_REQUEST, "AUTH009", "유효하지 않은 토큰입니다."),
-    INVALID_PRINCIPAL(BAD_REQUEST, "AUTH010", "인증정보가 존재하지 않습니다.");
+    INVALID_TOKEN_SIGNATURE(BAD_REQUEST, "AUTH010", "유효하지 않은 시그니처를 가진 토큰입니다. 온전한 토큰이 맞는지 확인해주세요."),
+    INVALID_PRINCIPAL(BAD_REQUEST, "AUTH011", "인증정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Ness/Backend/global/error/ErrorCode.java
+++ b/src/main/java/Ness/Backend/global/error/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     LOGIN_FAILED(UNAUTHORIZED, "AUTH008", "로그인에 실패했습니다."),
     INVALID_TOKEN(BAD_REQUEST, "AUTH009", "유효하지 않은 토큰입니다."),
     INVALID_TOKEN_SIGNATURE(BAD_REQUEST, "AUTH010", "유효하지 않은 시그니처를 가진 토큰입니다. 온전한 토큰이 맞는지 확인해주세요."),
-    INVALID_PRINCIPAL(BAD_REQUEST, "AUTH011", "인증정보가 존재하지 않습니다.");
+    TOKEN_ERROR(BAD_REQUEST, "AUTH011", "기타 토큰 에러입니다."),
+    INVALID_PRINCIPAL(BAD_REQUEST, "AUTH012", "인증정보가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Ness/Backend/global/error/FilterExceptionHandler.java
+++ b/src/main/java/Ness/Backend/global/error/FilterExceptionHandler.java
@@ -1,6 +1,6 @@
 package Ness.Backend.global.error;
 
-import Ness.Backend.global.common.response.CommonResponse;
+import Ness.Backend.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
@@ -8,6 +8,6 @@ public class FilterExceptionHandler {
     public static void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().print(CommonResponse.jsonOf(errorCode));
+        response.getWriter().print(ApiResponse.jsonOf(errorCode));
     }
 }

--- a/src/main/java/Ness/Backend/global/error/FilterExceptionHandler.java
+++ b/src/main/java/Ness/Backend/global/error/FilterExceptionHandler.java
@@ -1,0 +1,13 @@
+package Ness.Backend.global.error;
+
+import Ness.Backend.global.common.response.CommonResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class FilterExceptionHandler {
+    public static void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().print(CommonResponse.jsonOf(errorCode));
+    }
+}

--- a/src/main/java/Ness/Backend/global/response/ApiResponse.java
+++ b/src/main/java/Ness/Backend/global/response/ApiResponse.java
@@ -1,4 +1,4 @@
-package Ness.Backend.global.common.response;
+package Ness.Backend.global.response;
 
 import Ness.Backend.global.error.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -9,7 +9,7 @@ import net.minidev.json.JSONObject;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-public class CommonResponse<T> {
+public class ApiResponse<T> {
     @JsonProperty("status")
     private int code;
 
@@ -24,15 +24,15 @@ public class CommonResponse<T> {
     private T data;
 
     @Builder
-    public CommonResponse(int code, boolean success, String message, T data) {
+    public ApiResponse(int code, boolean success, String message, T data) {
         this.code = code;
         this.success = success;
         this.message = message;
         this.data = data;
     }
 
-    public static <T> CommonResponse<T> postResponse(int code, String message) {
-        return CommonResponse.<T>builder()
+    public static <T> ApiResponse<T> postResponse(int code, String message) {
+        return ApiResponse.<T>builder()
                 .code(code)
                 .success(true)
                 .message(message)
@@ -40,8 +40,8 @@ public class CommonResponse<T> {
                 .build();
     }
 
-    public static <T> CommonResponse<T> getResponse(int code, String message, T data) {
-        return CommonResponse.<T>builder()
+    public static <T> ApiResponse<T> getResponse(int code, String message, T data) {
+        return ApiResponse.<T>builder()
                 .code(code)
                 .success(true)
                 .message(message)
@@ -60,8 +60,8 @@ public class CommonResponse<T> {
         return jsonObject;
     }
 
-    public static <T> CommonResponse<T> onFailure(ErrorCode errorCode, String message) {
-        return CommonResponse.<T>builder()
+    public static <T> ApiResponse<T> onFailure(ErrorCode errorCode, String message) {
+        return ApiResponse.<T>builder()
                 .code(errorCode.getHttpStatus().value())
                 .success(false)
                 .message(message)


### PR DESCRIPTION
1. JWT 토큰 관련 에러가 발생시, filter단에서 에러 catch후 FilterExceptionHandler를 호출해 바로 HttpServletResponse 하는 로직 완성
2. TokenExpiredException, SignatureVerificationException 및 일반적인 Exception 처리 완성