### PR TITLE
[⚠️!HOTFIX] endTime이 null이면 startTime이랑 같이 맞춰주는 것으로 변경

### DIFF
--- a/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
+++ b/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
@@ -174,6 +174,10 @@ public class ScheduleService {
                                   ZonedDateTime startTime, ZonedDateTime endTime,
                                   Long category, Long memberId, Long scheduleId){
 
+        if(endTime == null){
+            endTime = startTime;
+        }
+
         PostFastApiScheduleDto dto = PostFastApiScheduleDto.builder()
                 .info(info)
                 .location(location)


### PR DESCRIPTION
1. AI 백엔드에서 null 값을 받지 않음->endTime이 null이면 startTime이랑 같이 맞춰주는 것으로 변경