### PR TITLE
[🚀feat] persona api 개발 완료

### DIFF
--- a/src/main/java/Ness/Backend/BackendApplication.java
+++ b/src/main/java/Ness/Backend/BackendApplication.java
@@ -2,7 +2,6 @@ package Ness.Backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 public class BackendApplication {

--- a/src/main/java/Ness/Backend/domain/chat/ChatService.java
+++ b/src/main/java/Ness/Backend/domain/chat/ChatService.java
@@ -9,6 +9,9 @@ import Ness.Backend.domain.chat.entity.Chat;
 import Ness.Backend.domain.chat.entity.ChatType;
 import Ness.Backend.domain.member.MemberRepository;
 import Ness.Backend.domain.member.entity.Member;
+import Ness.Backend.domain.profile.ProfileRepository;
+import Ness.Backend.domain.profile.entity.PersonaType;
+import Ness.Backend.domain.profile.entity.Profile;
 import Ness.Backend.global.fastApi.FastApiChatApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +30,7 @@ import java.util.List;
 public class ChatService {
     private final ChatRepository chatRepository;
     private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
     private final FastApiChatApi fastApiChatApi;
 
     /* 새로운 채팅 생성 및 RDB에 저장 */
@@ -43,8 +47,8 @@ public class ChatService {
     }
 
     /* 일주일 치 채팅 데이터 가져오기*/
-    public GetChatListDto getOneWeekUserChat(Long id){
-        List<Chat> chatList = chatRepository.findOneWeekUserChatsByMember_Id(id);
+    public GetChatListDto getOneWeekUserChat(Long memberId){
+        List<Chat> chatList = chatRepository.findOneWeekUserChatsByMember_Id(memberId);
 
         // ChatListResponseDTO에 매핑
         List<GetChatDto> getChatDtos = chatList.stream()
@@ -60,8 +64,9 @@ public class ChatService {
     }
 
     /* 유저의 채팅을 AI에 전송한 후, 답변 및 유저 채팅을 RDB에 저장 */
-    public GetChatListDto postNewUserChat(Long id, PostUserChatDto postUserChatDto){
-        Member memberEntity = memberRepository.findMemberById(id);
+    public GetChatListDto postNewUserChat(Long memberId, PostUserChatDto postUserChatDto){
+        Member memberEntity = memberRepository.findMemberById(memberId);
+        Profile profileEntity = profileRepository.findProfileByMember_Id(memberId);
         //새로운 유저 채팅 저장
         Chat newUserChat = Chat.builder()
                 .createdDate(createdZonedDate())
@@ -73,7 +78,7 @@ public class ChatService {
 
         chatRepository.save(newUserChat);
 
-        PostFastApiAiChatDto AiDto = postNewAiChat(id, postUserChatDto.getText(), postUserChatDto.getChatType());
+        PostFastApiAiChatDto AiDto = postNewAiChat(memberId, postUserChatDto.getText(), postUserChatDto.getChatType(), profileEntity.getPersonaType());
 
         //AI 챗 답변 저장
         Chat newAiChat = Chat.builder()
@@ -86,14 +91,19 @@ public class ChatService {
                 .build();
 
         chatRepository.save(newAiChat);
-        return getOneWeekUserChat(id);
+        return getOneWeekUserChat(memberId);
     }
 
     /* AI에 채팅 전송하는 로직 */
-    public PostFastApiAiChatDto postNewAiChat(Long id, String text, ChatType chatType){
+    public PostFastApiAiChatDto postNewAiChat(Long id, String text, ChatType chatType, PersonaType personaType){
+        String persona = "default";
+        if (personaType == PersonaType.HARDNESS){
+            persona = "hard";
+        }
 
+        //TODO: member_id 전달하는 로직 만들어야 하지 않을까?(RAG를 위해)
         PostFastApiUserChatDto userDto = PostFastApiUserChatDto.builder()
-                .persona("default")
+                .persona(persona)
                 .chatType(chatType) // 유저가 키보드로 친 채팅인지, 아니면 STT를 썼는지 구분
                 .message(text)
                 .build();

--- a/src/main/java/Ness/Backend/domain/member/MemberService.java
+++ b/src/main/java/Ness/Backend/domain/member/MemberService.java
@@ -2,6 +2,7 @@ package Ness.Backend.domain.member;
 
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.domain.profile.ProfileRepository;
+import Ness.Backend.domain.profile.entity.PersonaType;
 import Ness.Backend.domain.profile.entity.Profile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -34,6 +35,7 @@ public class MemberService {
                 .name(name)
                 .member(member)
                 .isEmailActive(isEmailActive)
+                .personaType(PersonaType.NESS) //디폴트로 NESS를 저장해줌, 나중에 개인 페이지에서 변경 가능
                 .build();
 
         profileRepository.save(profile);

--- a/src/main/java/Ness/Backend/domain/profile/ProfileController.java
+++ b/src/main/java/Ness/Backend/domain/profile/ProfileController.java
@@ -3,20 +3,20 @@ package Ness.Backend.domain.profile;
 
 import Ness.Backend.domain.member.entity.Member;
 import Ness.Backend.domain.profile.dto.request.PatchNicknameDto;
+import Ness.Backend.domain.profile.dto.request.PatchPersonaDto;
 import Ness.Backend.domain.profile.dto.response.GetProfileDto;
 import Ness.Backend.global.auth.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/profile")
+@Slf4j
 public class ProfileController {
     private final ProfileService profileService;
 
@@ -28,8 +28,15 @@ public class ProfileController {
 
     @PatchMapping("/nickname")
     @Operation(summary = "프로필 닉네임 변경 API", description = "사용자의 ID로 프로필 닉네임을 변경하는 API 입니다.")
-    public ResponseEntity<Long> userLogin(@AuthUser Member member, PatchNicknameDto patchNicknameDto) {
+    public ResponseEntity<Long> patchNickname(@AuthUser Member member, @RequestBody PatchNicknameDto patchNicknameDto) {
         Long profileId = profileService.updateNickname(member.getId(), patchNicknameDto.getNickname());
+        return new ResponseEntity<>(profileId, HttpStatusCode.valueOf(200));
+    }
+
+    @PatchMapping("/persona")
+    @Operation(summary = "페르소나 변경 API", description = "페르소나를 변경하는 API 입니다.")
+    public ResponseEntity<Long> patchPersona(@AuthUser Member member, @RequestBody PatchPersonaDto patchPersonaDto) {
+        Long profileId = profileService.updatePersona(member.getId(), patchPersonaDto.getPersona());
         return new ResponseEntity<>(profileId, HttpStatusCode.valueOf(200));
     }
 }

--- a/src/main/java/Ness/Backend/domain/profile/ProfileService.java
+++ b/src/main/java/Ness/Backend/domain/profile/ProfileService.java
@@ -1,20 +1,32 @@
 package Ness.Backend.domain.profile;
 
 import Ness.Backend.domain.profile.dto.response.GetProfileDto;
+import Ness.Backend.domain.profile.entity.PersonaType;
 import Ness.Backend.domain.profile.entity.Profile;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ProfileService {
     private final ProfileRepository profileRepository;
-    public Long updateNickname(Long id, String nickname) {
+    public Long updateNickname(Long memberId, String nickname) {
         //JPA 변경 감지 사용
-        Profile profile = profileRepository.findProfileByMember_Id(id);
+        Profile profile = profileRepository.findProfileByMember_Id(memberId);
         profile.updateNickname(nickname);
+
+        //결과로 profile의 ID 반환
+        return profile.getId();
+    }
+
+    public Long updatePersona(Long memberId, PersonaType personaType) {
+        //JPA 변경 감지 사용
+        Profile profile = profileRepository.findProfileByMember_Id(memberId);
+        profile.updatePersona(personaType);
 
         //결과로 profile의 ID 반환
         return profile.getId();
@@ -28,6 +40,8 @@ public class ProfileService {
                 .pictureUrl(profile.getPictureUrl())
                 .nickname(profile.getNickname())
                 .name(profile.getName())
+                .isEmailActive(profile.getIsEmailActive())
+                .persona(profile.getPersonaType())
                 .build();
 
         return getProfileDto;

--- a/src/main/java/Ness/Backend/domain/profile/dto/request/PatchPersonaDto.java
+++ b/src/main/java/Ness/Backend/domain/profile/dto/request/PatchPersonaDto.java
@@ -1,0 +1,15 @@
+package Ness.Backend.domain.profile.dto.request;
+
+import Ness.Backend.domain.profile.entity.PersonaType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PatchPersonaDto {
+    @Schema(description = "업데이트할 사용자 페르소나", example = "NESS")
+    @JsonProperty("persona")
+    private PersonaType persona;
+}

--- a/src/main/java/Ness/Backend/domain/profile/dto/response/GetProfileDto.java
+++ b/src/main/java/Ness/Backend/domain/profile/dto/response/GetProfileDto.java
@@ -1,6 +1,9 @@
 package Ness.Backend.domain.profile.dto.response;
 
 
+import Ness.Backend.domain.profile.entity.PersonaType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
@@ -22,11 +25,21 @@ public class GetProfileDto {
     @Schema(description = "사용자의 이름", example = "홍길동")
     private String name;
 
+    @Schema(description = "사용자가 설정한 페르소나", example = "NESS")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private PersonaType persona;
+
+    @Schema(description = "사용자가 설정한 이메일 알림 여부", example = "NESS")
+    @JsonProperty("isEmailActive")
+    private boolean isEmailActive;
+
     @Builder
-    public GetProfileDto(Long id, String pictureUrl, String nickname, String name){
+    public GetProfileDto(Long id, String pictureUrl, String nickname, String name, PersonaType persona, boolean isEmailActive){
         this.id = id;
         this.pictureUrl = pictureUrl;
         this.nickname = nickname;
         this.name = name;
+        this.persona = persona;
+        this.isEmailActive = isEmailActive;
     }
 }

--- a/src/main/java/Ness/Backend/domain/profile/entity/PersonaType.java
+++ b/src/main/java/Ness/Backend/domain/profile/entity/PersonaType.java
@@ -1,0 +1,5 @@
+package Ness.Backend.domain.profile.entity;
+
+public enum PersonaType {
+    NESS, HARDNESS, CLAMNESS
+}

--- a/src/main/java/Ness/Backend/domain/profile/entity/Profile.java
+++ b/src/main/java/Ness/Backend/domain/profile/entity/Profile.java
@@ -23,6 +23,10 @@ public class Profile {
 
     private Boolean isEmailActive;
 
+    //유저 페르소나를 구분해주는 타입 값
+    @Enumerated(EnumType.STRING)
+    private PersonaType personaType;
+
     @OneToOne
     @JoinColumn(name = "member_id")
     private Member member;
@@ -35,12 +39,17 @@ public class Profile {
         this.isEmailActive = isEmailActive;
     }
 
+    public void updatePersona(PersonaType personaType){
+        this.personaType = personaType;
+    }
+
     @Builder
-    public Profile(String pictureUrl, String nickname, String name, Member member, Boolean isEmailActive){
+    public Profile(String pictureUrl, String nickname, String name, Member member, Boolean isEmailActive, PersonaType personaType){
         this.pictureUrl = pictureUrl;
         this.nickname = nickname;
         this.name = name;
         this.member = member;
         this.isEmailActive = isEmailActive;
+        this.personaType = personaType;
     }
 }


### PR DESCRIPTION
1. persona 타입 생성, profile의 필드로 적용 및 기존 프로필 데이터에 일괄 적용
2. 맴버 생성시 자동으로 디폴트 페르소나인 NESS로 저장되도록 변경
3. AI 백엔드에 채팅 전송시 "default" 하드코딩하지 말고 DB에 저장된 값을 가져오도록 변경
4. 사용자가 설정한 페르소나대로 ChatGPT 답변이 오는 것을 확인