### PR TITLE
[🔧fix] 쿼리에서 타임존 설정 실수 수정

### DIFF
--- a/src/main/java/Ness/Backend/domain/schedule/ScheduleRepository.java
+++ b/src/main/java/Ness/Backend/domain/schedule/ScheduleRepository.java
@@ -15,8 +15,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 특정 맴버의 한달 치 스케쥴 반환
     @Query( value = "SELECT * FROM schedule " +
                     "WHERE member_id = :memberId " +
-                    "AND YEAR(CONVERT_TZ(start_time, '+00:00', '+09:00')) = CONVERT_TZ(:year, '+00:00', '+09:00')" +
-                    "AND MONTH(CONVERT_TZ(start_time, '+00:00', '+09:00')) = CONVERT_TZ(:month, '+00:00', '+09:00')" +
+                    "AND YEAR(CONVERT_TZ(start_time, '+00:00', '+09:00')) = :year " +
+                    "AND MONTH(CONVERT_TZ(start_time, '+00:00', '+09:00')) = :month " +
                     "ORDER BY start_time ASC",
             nativeQuery = true)
     List<Schedule> findOneMonthSchedulesByMember_Id(


### PR DESCRIPTION
1. ZoneDateTime 뿐만 아니라 변수에도 CONVERT_TZ 설정되어 있던 문제 수정