### PR TITLE
[⚠️!HOTFIX] person, location이 null일 경우 에러 수정

### DIFF
--- a/src/main/java/Ness/Backend/domain/todo/TodoService.java
+++ b/src/main/java/Ness/Backend/domain/todo/TodoService.java
@@ -53,9 +53,9 @@ public class TodoService {
                                     .name(schedule.getCategory().getName())
                                     .color(schedule.getCategory().getColor())
                                     .build())
-                            .person(schedule.getPerson())
-                            .location(schedule.getLocation())
-                            .info(schedule.getInfo())
+                            .person(schedule.getPerson() != null ? schedule.getPerson() : "")
+                            .location(schedule.getLocation() != null ? schedule.getLocation() : "")
+                            .info(schedule.getInfo() != null ? schedule.getInfo() : "")
                             .build())
                     .toList();
 


### PR DESCRIPTION
1. fastAPI에 전송할 때 person, location이 null일 경우 500에러 나는 것을 빈 문자열 전송으로 해결

#100 