### PR TITLE
[🎨refact] 메인 API를 비동기로 변경

### DIFF
--- a/src/main/java/Ness/Backend/domain/main/MainService.java
+++ b/src/main/java/Ness/Backend/domain/main/MainService.java
@@ -32,7 +32,9 @@ public class MainService {
             PostFastApiAiRecommendActivityDto activityDtos = activityFuture.get();
             return toEntity(scheduleDtos, activityDtos);
 
-        } catch (Exception exception){
+        }
+        // 비동기 에러 발생시 동기 처리를 하더라도 메인 API 제공되도록 로직 설정
+        catch (Exception exception){
             List<GetScheduleDto> scheduleDtos = todoService.getTodo(memberId);
             PostFastApiAiRecommendActivityDto activityDtos = reportService.getRecommendActivity(memberId);
             return toEntity(scheduleDtos, activityDtos);

--- a/src/main/java/Ness/Backend/domain/report/ReportService.java
+++ b/src/main/java/Ness/Backend/domain/report/ReportService.java
@@ -43,19 +43,19 @@ public class ReportService {
     private final ProfileRepository profileRepository;
 
     /* 메모리 가져오는 로직 */
-    public GetReportMemoryListDto getMemory(Long id){
-        log.info("getMemory called by member: " + id);
+    public GetReportMemoryListDto getMemory(Long memberId){
+        log.info("getMemory called by member: " + memberId);
 
         // 오늘 날짜 가져오기
         ZonedDateTime now = getToday();
 
-        ReportMemory reportMemory = reportMemoryRepository.findTodayReportMemoryByMember_Id(id);
+        ReportMemory reportMemory = reportMemoryRepository.findTodayReportMemoryByMember_Id(memberId);
 
         if (reportMemory == null){
             // 오늘치가 없다면 새롭게 생성하기
-            String memory = postNewAiMemory(id, now);
+            String memory = postNewAiMemory(memberId, now);
 
-            Member memberEntity = memberRepository.findMemberById(id);
+            Member memberEntity = memberRepository.findMemberById(memberId);
 
             ReportMemory newMemory = ReportMemory.builder()
                     .createdDate(now)
@@ -67,7 +67,7 @@ public class ReportService {
         }
 
         // 2주치의 데이터 가져오기
-        List<ReportMemory> reportMemories = reportMemoryRepository.findTwoWeekUserMemoryByMember_Id(id);
+        List<ReportMemory> reportMemories = reportMemoryRepository.findTwoWeekUserMemoryByMember_Id(memberId);
         return createReportMemoryListDto(reportMemories);
     }
 
@@ -84,10 +84,10 @@ public class ReportService {
         return new GetReportMemoryListDto(getReportMemoryDtos);
     }
 
-    public String postNewAiMemory(Long id, ZonedDateTime today){
-        String persona = getPersona(id);
+    public String postNewAiMemory(Long memberId, ZonedDateTime today){
+        String persona = getPersona(memberId);
         PostFastApiUserMemoryDto userDto = PostFastApiUserMemoryDto.builder()
-                .member_id(id.intValue())
+                .member_id(memberId.intValue())
                 .user_persona(persona)
                 .schedule_datetime_start(today)
                 .schedule_datetime_end(today)
@@ -100,18 +100,18 @@ public class ReportService {
     }
 
     /* 테그 가져오는 로직 */
-    public GetReportTagListDto getTag(Long id){
-        log.info("getTag called by member: " + id);
+    public GetReportTagListDto getTag(Long memberId){
+        log.info("getTag called by member: " + memberId);
 
         // 오늘 날짜 가져오기
         ZonedDateTime now = getToday();
 
-        List<ReportTag> reportTags = reportTagRepository.findLastMonthReportTagByMember_Id(id);
+        List<ReportTag> reportTags = reportTagRepository.findLastMonthReportTagByMember_Id(memberId);
 
         if (reportTags == null || reportTags.isEmpty()) {
-            PostFastApiAiTagListDto aiDto = postNewAiTag(id, getToday());
+            PostFastApiAiTagListDto aiDto = postNewAiTag(memberId, getToday());
 
-            Member memberEntity = memberRepository.findMemberById(id);
+            Member memberEntity = memberRepository.findMemberById(memberId);
 
             for (PostFastApiAiTagDto tag : aiDto.getTags()) {
                 ReportTag reportTag = ReportTag.builder()
@@ -122,7 +122,7 @@ public class ReportService {
                         .build();
                 reportTagRepository.save(reportTag);
             }
-            return createReportTagListDto(reportTagRepository.findLastMonthReportTagByMember_Id(id));
+            return createReportTagListDto(reportTagRepository.findLastMonthReportTagByMember_Id(memberId));
         } else {
             return createReportTagListDto(reportTags);
         }
@@ -141,14 +141,14 @@ public class ReportService {
         return new GetReportTagListDto(getReportTagDtos);
     }
 
-    public PostFastApiAiTagListDto getAiTag(Long id){
-        return postNewAiTag(id, getToday());
+    public PostFastApiAiTagListDto getAiTag(Long memberId){
+        return postNewAiTag(memberId, getToday());
     }
 
-    public PostFastApiAiTagListDto postNewAiTag(Long id, ZonedDateTime today){
-        String persona = getPersona(id);
+    public PostFastApiAiTagListDto postNewAiTag(Long memberId, ZonedDateTime today){
+        String persona = getPersona(memberId);
         PostFastApiUserTagDto userDto = PostFastApiUserTagDto.builder()
-                .member_id(id.intValue())
+                .member_id(memberId.intValue())
                 .user_persona(persona)
                 .schedule_datetime_start(today)
                 .schedule_datetime_end(today)
@@ -215,10 +215,10 @@ public class ReportService {
         }
     }
 
-    public PostFastApiAiRecommendActivityDto postNewAiRecommend(Long id, ZonedDateTime today){
-        String persona = getPersona(id);
+    public PostFastApiAiRecommendActivityDto postNewAiRecommend(Long memberId, ZonedDateTime today){
+        String persona = getPersona(memberId);
         PostFastApiUserRecommendActivityDto userDto = PostFastApiUserRecommendActivityDto.builder()
-                .member_id(id.intValue())
+                .member_id(memberId.intValue())
                 .user_persona(persona)
                 .schedule_datetime_start(today)
                 .schedule_datetime_end(today)

--- a/src/main/java/Ness/Backend/domain/report/ReportService.java
+++ b/src/main/java/Ness/Backend/domain/report/ReportService.java
@@ -2,6 +2,9 @@ package Ness.Backend.domain.report;
 
 import Ness.Backend.domain.member.MemberRepository;
 import Ness.Backend.domain.member.entity.Member;
+import Ness.Backend.domain.profile.ProfileRepository;
+import Ness.Backend.domain.profile.entity.PersonaType;
+import Ness.Backend.domain.profile.entity.Profile;
 import Ness.Backend.domain.report.dto.request.PostFastApiUserMemoryDto;
 import Ness.Backend.domain.report.dto.request.PostFastApiUserRecommendActivityDto;
 import Ness.Backend.domain.report.dto.request.PostFastApiUserTagDto;
@@ -37,6 +40,7 @@ public class ReportService {
     private final FastApiTagApi fastApiTagApi;
     private final FastApiMemoryApi fastApiMemoryApi;
     private final MemberRepository memberRepository;
+    private final ProfileRepository profileRepository;
 
     /* 메모리 가져오는 로직 */
     public GetReportMemoryListDto getMemory(Long id){
@@ -81,9 +85,10 @@ public class ReportService {
     }
 
     public String postNewAiMemory(Long id, ZonedDateTime today){
+        String persona = getPersona(id);
         PostFastApiUserMemoryDto userDto = PostFastApiUserMemoryDto.builder()
                 .member_id(id.intValue())
-                .user_persona("")
+                .user_persona(persona)
                 .schedule_datetime_start(today)
                 .schedule_datetime_end(today)
                 .build();
@@ -141,9 +146,10 @@ public class ReportService {
     }
 
     public PostFastApiAiTagListDto postNewAiTag(Long id, ZonedDateTime today){
+        String persona = getPersona(id);
         PostFastApiUserTagDto userDto = PostFastApiUserTagDto.builder()
                 .member_id(id.intValue())
-                .user_persona("")
+                .user_persona(persona)
                 .schedule_datetime_start(today)
                 .schedule_datetime_end(today)
                 .build();
@@ -210,9 +216,10 @@ public class ReportService {
     }
 
     public PostFastApiAiRecommendActivityDto postNewAiRecommend(Long id, ZonedDateTime today){
+        String persona = getPersona(id);
         PostFastApiUserRecommendActivityDto userDto = PostFastApiUserRecommendActivityDto.builder()
                 .member_id(id.intValue())
-                .user_persona("") // 빈 문자열은 default
+                .user_persona(persona)
                 .schedule_datetime_start(today)
                 .schedule_datetime_end(today)
                 .build();
@@ -227,6 +234,21 @@ public class ReportService {
 
     public ZonedDateTime getToday(){
         return ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    public String getPersona(Long memberId){
+        Profile profileEntity = profileRepository.findProfileByMember_Id(memberId);
+        PersonaType personaType = profileEntity.getPersonaType();
+
+        String persona = "default";
+        if (personaType == PersonaType.HARDNESS){
+            persona = "hard";
+        }
+        if (personaType == PersonaType.CALMNESS){
+            persona = "calm";
+        }
+
+        return persona;
     }
 
 }

--- a/src/main/java/Ness/Backend/domain/report/ReportService.java
+++ b/src/main/java/Ness/Backend/domain/report/ReportService.java
@@ -40,6 +40,8 @@ public class ReportService {
 
     /* 메모리 가져오는 로직 */
     public GetReportMemoryListDto getMemory(Long id){
+        log.info("getMemory called by member: " + id);
+
         // 오늘 날짜 가져오기
         ZonedDateTime now = getToday();
 
@@ -94,6 +96,8 @@ public class ReportService {
 
     /* 테그 가져오는 로직 */
     public GetReportTagListDto getTag(Long id){
+        log.info("getTag called by member: " + id);
+
         // 오늘 날짜 가져오기
         ZonedDateTime now = getToday();
 
@@ -150,6 +154,8 @@ public class ReportService {
 
     /* 한 줄 추천 및 엑티비티 가져오는 로직 */
     public PostFastApiAiRecommendActivityDto getRecommendActivity(Long memberId){
+        log.info("getRecommendActivity called by member: " + memberId);
+
         // 오늘 날짜 가져오기
         ZonedDateTime now = getToday();
         List<ReportRecommend> reportRecommends = reportRecommendRepository.findTodayReportRecommendByMember_Id(memberId);

--- a/src/main/java/Ness/Backend/domain/todo/TodoService.java
+++ b/src/main/java/Ness/Backend/domain/todo/TodoService.java
@@ -34,6 +34,8 @@ public class TodoService {
 
     /* 일정 관련 한 줄 추천 가져오는 로직 */
     public List<GetScheduleDto> getTodo(Long memberId){
+        log.info("getTodo called by member: " + memberId);
+
         Profile userProfile = profileRepository.findProfileByMember_Id(memberId);
         // 오늘 날짜 가져오기
         ZonedDateTime now = time.getToday();


### PR DESCRIPTION
1. 메인 API 호출시 AI 백엔드를 2번 호출하던 로직이 기존에는 동기로 순서대로 처리되는 방식
2. 비동기로 변경해 API 2개를 동시에 호출, 시간 소요를 절반으로 줄임