### PR TITLE
[⚠️!HOTFIX] 리포트 메모리 500에러 수정

### DIFF
--- a/src/main/java/Ness/Backend/domain/report/ReportMemoryRepository.java
+++ b/src/main/java/Ness/Backend/domain/report/ReportMemoryRepository.java
@@ -12,19 +12,26 @@ public interface ReportMemoryRepository extends JpaRepository<ReportMemory, Long
     // 특정 맴버의 오늘 하루 생성된 데이터만 반환
     @Query( value = "SELECT * FROM report_memory " +
             "WHERE member_id = :memberId " +
-            "AND DATE(CONVERT_TZ(created_date, '+00:00', '+09:00')) = CURDATE() " +
+            "AND DATE(CONVERT_TZ(created_date, '+00:00', '+09:00')) = DATE(CONVERT_TZ(NOW(), '+00:00', '+09:00')) " +
             "ORDER BY created_date ASC",
             nativeQuery = true)
-    ReportMemory findTodayReportMemoryByMember_Id(
+    List<ReportMemory> findTodayReportMemoryByMember_Id(
             @Param("memberId") Long memberId);
 
-    @Query( value = "SELECT * FROM report_memory " +
+
+    // 특정 맴버의 2주치 생성된 데이터 반환(단, 하루에 만드시 한개씩 반환, 2주치면 최대 14개)
+    @Query(value = "SELECT * FROM ( " +
+            "SELECT report_memory.*, ROW_NUMBER() OVER (PARTITION BY DATE(CONVERT_TZ(created_date, '+00:00', '+09:00')) " +
+            "ORDER BY created_date DESC) as row_num " +
+            "FROM report_memory " +
             "WHERE member_id = :memberId " +
-            "AND created_date >= DATE_SUB(NOW(), INTERVAL 2 WEEK) " +
-            "ORDER BY created_date ASC",
+            "AND created_date >= CONVERT_TZ(DATE_SUB(NOW(), INTERVAL 2 WEEK), '+00:00', '+09:00') " +
+            ") AS subquery " +
+            "WHERE row_num = 1 " +
+            "ORDER BY created_date ASC " +
+            "LIMIT 14",
             nativeQuery = true)
     List<ReportMemory> findTwoWeekUserMemoryByMember_Id(
             @Param("memberId") Long memberId);
 
-    List<ReportMemory> findReportMemoriesByMember_idAndCreatedDateBetweenOrderByCreatedDateAsc(Long id, ZonedDateTime startOfWeek, ZonedDateTime now);
 }

--- a/src/main/java/Ness/Backend/domain/report/ReportService.java
+++ b/src/main/java/Ness/Backend/domain/report/ReportService.java
@@ -49,9 +49,9 @@ public class ReportService {
         // 오늘 날짜 가져오기
         ZonedDateTime now = getToday();
 
-        ReportMemory reportMemory = reportMemoryRepository.findTodayReportMemoryByMember_Id(memberId);
+        List<ReportMemory> reportMemory = reportMemoryRepository.findTodayReportMemoryByMember_Id(memberId);
 
-        if (reportMemory == null){
+        if (reportMemory.isEmpty()){
             // 오늘치가 없다면 새롭게 생성하기
             String memory = postNewAiMemory(memberId, now);
 
@@ -166,7 +166,7 @@ public class ReportService {
         ZonedDateTime now = getToday();
         List<ReportRecommend> reportRecommends = reportRecommendRepository.findTodayReportRecommendByMember_Id(memberId);
 
-        if(reportRecommends.isEmpty()){
+        if(reportRecommends == null || reportRecommends.isEmpty()){
             //새로운 한 줄 추천 및 엑티비티 생성하기
             PostFastApiAiRecommendActivityDto aiDto = postNewAiRecommend(memberId, now);
             aiDto.setAnswer(parseAiRecommend(aiDto.getAnswer()));


### PR DESCRIPTION
1. 하루에 한 개 이상의 리포트 메모리 데이터가 들어있을 경우 에러 발생, 따라서 하루치 리포트 메모리 검색시 List로 반환하도록 로직 수정
2. 페르소나가 리포트에서 적용되고 있지 않던 점 수정, 일괄 적용되도록 변경
3. 2주치 리포트 메모리 데이터가 반드시 하루 한 개의 데이터만 가져오고, 총 14개의 데이터를 가져오도록 LIMIT 걸도록 로직 수정

closed #108 