### PR TITLE
[🔧fix] 스케쥴 GET 500에러

### DIFF
--- a/src/main/java/Ness/Backend/domain/member/MemberService.java
+++ b/src/main/java/Ness/Backend/domain/member/MemberService.java
@@ -71,7 +71,7 @@ public class MemberService {
         //핑크
         Category restCategory = Category.builder()
                 .member(member)
-                .name("\uD83D\uDEDF여가")
+                .name("✨여가")
                 .color("#FF75C8")
                 .build();
 

--- a/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
+++ b/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
@@ -14,6 +14,7 @@ import Ness.Backend.domain.schedule.dto.response.GetScheduleDetailDto;
 import Ness.Backend.domain.schedule.dto.response.GetScheduleDto;
 import Ness.Backend.domain.schedule.dto.response.GetScheduleListDto;
 import Ness.Backend.domain.schedule.entity.Schedule;
+import Ness.Backend.global.error.exception.NotFoundCategoryException;
 import Ness.Backend.global.fastApi.FastApiDeleteScheduleApi;
 import Ness.Backend.global.fastApi.FastApiPostScheduleApi;
 import Ness.Backend.global.fastApi.FastApiPutScheduleApi;
@@ -137,25 +138,30 @@ public class ScheduleService {
         Member member = memberRepository.findMemberById(memberId);
         Category category = categoryRepository.findCategoryById(postScheduleDto.getCategoryNum());
 
+        /* 사용자가 Accept 했으면 스케쥴 생성하기 */
         if(idAccepted){
-            /* 사용자가 Accept 했으면 스케쥴 생성하기 */
-            Chat chat = chatRepository.findChatById(chatId);
+            /* 카테고리 연견관계가 정상적인 경우*/
+            if(category != null){
+                Chat chat = chatRepository.findChatById(chatId);
 
-            Schedule newSchedule = Schedule.builder()
-                    .info(postScheduleDto.getInfo())
-                    .location(postScheduleDto.getLocation())
-                    .person(postScheduleDto.getPerson())
-                    .startTime(postScheduleDto.getStartTime())
-                    .endTime(postScheduleDto.getEndTime())
-                    .member(member)
-                    .category(category)
-                    .chat(chat)
-                    .build();
+                Schedule newSchedule = Schedule.builder()
+                        .info(postScheduleDto.getInfo())
+                        .location(postScheduleDto.getLocation())
+                        .person(postScheduleDto.getPerson())
+                        .startTime(postScheduleDto.getStartTime())
+                        .endTime(postScheduleDto.getEndTime())
+                        .member(member)
+                        .category(category)
+                        .chat(chat)
+                        .build();
 
-            scheduleRepository.save(newSchedule);
+                scheduleRepository.save(newSchedule);
 
-            chatService.createNewChat("일정을 추가해드렸습니다:)", ChatType.AI, 1, member);
-
+                chatService.createNewChat("일정을 추가해드렸습니다:)", ChatType.AI, 1, member);
+            }
+            else{
+                throw new NotFoundCategoryException();
+            }
         } else {
             chatService.createNewChat("일정 추가를 취소했습니다.\n더 필요한 것이 있으시면 알려주세요!", ChatType.AI, 1, member);
         }

--- a/src/main/java/Ness/Backend/global/error/ErrorCode.java
+++ b/src/main/java/Ness/Backend/global/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     /* 카테고리 관련 */
     INVALID_CATEGORY_NAME(CONFLICT, "CATE001", "해당 카테고리명이 이미 존재합니다. 카테고리명은 중복될 수 없습니다."),
     INVALID_CATEGORY_DELETE(BAD_REQUEST, "CATE002", "미분류 카테고리는 삭제 불가능합니다."),
+    NOTFOUND_CATEGORY(BAD_REQUEST, "CATE003", "해당 카테고리가 해당 맴버에게 존재하지 않습니다."),
 
     /* 리포트 관련 */
     MISMATCH_REPORT_RECOMMEND(BAD_REQUEST, "RPT001", "한 줄 추천이 존재하지 않습니다.");

--- a/src/main/java/Ness/Backend/global/error/exception/NotFoundCategoryException.java
+++ b/src/main/java/Ness/Backend/global/error/exception/NotFoundCategoryException.java
@@ -1,0 +1,16 @@
+package Ness.Backend.global.error.exception;
+
+import Ness.Backend.global.error.ErrorCode;
+import lombok.Getter;
+@Getter
+public class NotFoundCategoryException extends BaseException {
+    public NotFoundCategoryException() {
+        super(ErrorCode.NOTFOUND_CATEGORY, ErrorCode.NOTFOUND_CATEGORY.getMessage());
+    }
+    public NotFoundCategoryException(String message) {
+        super(ErrorCode.NOTFOUND_CATEGORY, message);
+    }
+    public NotFoundCategoryException(ErrorCode errorCode) {
+        super(errorCode, errorCode.getMessage());
+    }
+}


### PR DESCRIPTION
1. 기존에는 카테고리가 null이여도 스케쥴이 저장되던 에러를 커스텀 예외 처리로 명시적 거부
2. 카테고리가 없는 경우 DB에 저장되지 못하도록 변경
3. "여가" 카테고리가 사용하는 이모지가 JSON에서 파싱되지 못하는 관계로, 다른 이모지로 변경

closes #118 