### PR TITLE
[🔧fix] VectorDB에 저장되는 시간을 한국 시간대로 변경

### DIFF
--- a/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
+++ b/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
@@ -210,16 +210,18 @@ public class ScheduleService {
                                   ZonedDateTime startTime, ZonedDateTime endTime,
                                   String category, Long category_id, Long memberId, Long scheduleId){
 
+        // null 값은 전달되서는 안됨
         if(endTime == null){
             endTime = startTime;
         }
 
+        // 서울 시간대로 VectorDB에 저장
         PostFastApiScheduleDto dto = PostFastApiScheduleDto.builder()
                 .info(info)
                 .location(location)
                 .person(person)
-                .startTime(startTime)
-                .endTime(endTime)
+                .startTime(startTime.withZoneSameInstant(ZoneId.of("Asia/Seoul")))
+                .endTime(endTime.withZoneSameInstant(ZoneId.of("Asia/Seoul")))
                 .category(category)
                 .category_id(category_id)
                 .member_id(memberId)


### PR DESCRIPTION
1. VectorDB에 기준 시간대로 전달하던 시간을 한국 시간대로 변경해서 전달되도록 수정