### PR TITLE
[🔧fix] 채팅과 일정 연관관계 1:1에서 1:N으로 변경

### DIFF
--- a/src/main/java/Ness/Backend/domain/chat/entity/Chat.java
+++ b/src/main/java/Ness/Backend/domain/chat/entity/Chat.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,8 +30,8 @@ public class Chat {
     @Enumerated(EnumType.STRING)
     private ChatType chatType;
 
-    @OneToOne(mappedBy = "chat", fetch = FetchType.LAZY)
-    private Schedule schedule;
+    @OneToMany(mappedBy = "chat", fetch = FetchType.LAZY)
+    private List<Schedule> schedules = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -37,13 +39,12 @@ public class Chat {
 
     @Builder
     public Chat(Long id, ZonedDateTime createdDate, String text, ChatType chatType,
-                int caseNumber, Schedule schedule, Member member) {
+                int caseNumber, Member member) {
         this.id = id;
         this.createdDate = createdDate;
         this.text = text;
         this.chatType = chatType;
         this.caseNumber = caseNumber;
-        this.schedule = schedule;
         this.member = member;
     }
 }

--- a/src/main/java/Ness/Backend/domain/schedule/entity/Schedule.java
+++ b/src/main/java/Ness/Backend/domain/schedule/entity/Schedule.java
@@ -39,7 +39,7 @@ public class Schedule {
     @JoinColumn(name = "category_id")
     private Category category;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_id")
     private Chat chat;
 


### PR DESCRIPTION
1. feature가 변경됨에 따라서 채팅과 일정 연관관계가 1:1에서 1:N으로 변경, 이에 따라서 JPA 연관관계를 변경 완료