### PR TITLE
[🔧fix] VectorDB에 저장할 스케쥴 데이터에 카테고리 컬러 추가

### DIFF
--- a/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
+++ b/src/main/java/Ness/Backend/domain/schedule/ScheduleService.java
@@ -95,6 +95,7 @@ public class ScheduleService {
                 .endTime(endTime)
                 .category(category.getName())
                 .category_id(category.getId())
+                .category_color(category.getColor())
                 .member_id(memberId)
                 .schedule_id(putScheduleDto.getId())
                 .build();
@@ -239,6 +240,7 @@ public class ScheduleService {
                 postScheduleDto.getEndTime(),
                 category.getName(),
                 category.getId(),
+                category.getColor(),
                 newSchedule.getMember().getId(),
                 newSchedule.getId());
 
@@ -249,7 +251,7 @@ public class ScheduleService {
     /* 새로운 스케쥴을 VectorDB에 저장하는 API 호출 */
     public void postNewAiSchedule(String info, String location, String person,
                                   ZonedDateTime startTime, ZonedDateTime endTime,
-                                  String category, Long category_id, Long memberId, Long scheduleId){
+                                  String category, Long category_id, String category_color, Long memberId, Long scheduleId){
 
         // null 값은 전달되서는 안됨
         if(endTime == null){
@@ -265,6 +267,7 @@ public class ScheduleService {
                 .endTime(endTime.withZoneSameInstant(ZoneId.of("Asia/Seoul")))
                 .category(category)
                 .category_id(category_id)
+                .category_color(category_color)
                 .member_id(memberId)
                 .schedule_id(scheduleId)
                 .build();

--- a/src/main/java/Ness/Backend/domain/schedule/dto/request/PostFastApiScheduleDto.java
+++ b/src/main/java/Ness/Backend/domain/schedule/dto/request/PostFastApiScheduleDto.java
@@ -43,4 +43,7 @@ public class PostFastApiScheduleDto {
 
     @JsonProperty("category_id")
     private Long category_id;
+
+    @JsonProperty("category_color")
+    private String category_color;
 }

--- a/src/main/java/Ness/Backend/domain/schedule/dto/request/PutFastApiScheduleDto.java
+++ b/src/main/java/Ness/Backend/domain/schedule/dto/request/PutFastApiScheduleDto.java
@@ -42,4 +42,7 @@ public class PutFastApiScheduleDto {
 
     @JsonProperty("category_id")
     private Long category_id;
+
+    @JsonProperty("category_color")
+    private String category_color;
 }


### PR DESCRIPTION
1. 기존에는 VectorDB에 카테고리 컬러가 있지 않아서 chat으로 스케쥴 삭제시 카테고리 컬러가 표현되지 않았음
2. VectorDB에도 카테고리 컬러 저장해서 chat에서도 표현되도록 변경