### PR TITLE
[🔧fix] 디스코드 알림 중 HttpRequestMethodNotSupportedException은 알림에서 제외

### DIFF
--- a/src/main/java/Ness/Backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/Ness/Backend/global/error/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,6 +34,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException noResourceFoundException, HttpServletRequest httpServletRequest) {
         log.error("handleNoResourceFoundException", noResourceFoundException);
+        final ContentCachingRequestWrapper contentCachingRequestWrapper = new ContentCachingRequestWrapper(httpServletRequest);
+        return new ResponseEntity<>(ErrorResponse.onFailure(ErrorCode._INTERNAL_SERVER_ERROR), null, INTERNAL_SERVER_ERROR);
+    }
+
+    // 잘못된 HTTP 메소드 요청 따로 처리(디스코드 알림에서 제외하기 위함)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException httpRequestMethodNotSupportedException, HttpServletRequest httpServletRequest) {
+        log.error("handleMethodNotSupportedException", httpRequestMethodNotSupportedException);
         final ContentCachingRequestWrapper contentCachingRequestWrapper = new ContentCachingRequestWrapper(httpServletRequest);
         return new ResponseEntity<>(ErrorResponse.onFailure(ErrorCode._INTERNAL_SERVER_ERROR), null, INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
1. 디스코드 알림 중 HttpRequestMethodNotSupportedException은 실제 클라이언트의 에러 보다는 디도스 공격으로 인한 에러가 훨씬 많음
2. 위의 이유로 실제 클라이언트의 에러를 확인할 수 없어 해당 에러는 디스코드 알림에서 제외